### PR TITLE
Capture renderer errors

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const electron = require('electron');
+const log = require('electron-log');
+log.transports.file.file = __dirname + '/log.txt';
 const fs = require('fs');
 const ipcMain = electron.ipcMain;
 // Module to control application life.
@@ -44,6 +46,11 @@ function createWindow () {
             }), undefined, 4);
             fs.writeFile('./current_layout.json', layoutJSON);
         }
+    });
+
+    // Setup log capture from renderer process
+    ipcMain.on('renderer-error', function(event, error) {
+        log.error(error);
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "browserify": "13.0.x",
         "classnames": "2.2.x",
         "electron": "1.4.x",
+        "electron-log": "1.3.x",
         "gulp": "3.9.x",
         "gulp-import-css": "0.1.x",
         "gulp-sass": "2.3.x",

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,11 @@ var layout = require('./layout.json');
  * Top-level dashboard component.
  */
 var ACMDisplay = React.createClass({
+    componentWillMount: function() {
+        window.onerror = function(err) {
+            ipcRenderer.send('renderer-error', err);
+        };
+    },
     onLayoutChange: function(currentLayout, layouts) {
         ipcRenderer.send('layout-changed', currentLayout);
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -940,9 +940,13 @@ electron-download@^3.0.1:
     semver "^5.3.0"
     sumchecker "^1.2.0"
 
-electron@^1.4.13:
-  version "1.4.13"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.4.13.tgz#aecc073484c25d351007d75ad8972b0f2f835ab3"
+electron-log@1.3.x:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-1.3.0.tgz#d05544114b971a16c86739c79d0d236103ad0a16"
+
+electron@1.4.x:
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.4.15.tgz#eaccafe3f55ade02a746b706ac14b43db6c7ccf8"
   dependencies:
     electron-download "^3.0.1"
     extract-zip "^1.0.3"


### PR DESCRIPTION
Right now, we don't have a good way of viewing client-side errors for display.

This PR has `display` log errors to a file to help in debugging.