### PR TITLE
Fix ad panel's width/height

### DIFF
--- a/sass/panels/ads.scss
+++ b/sass/panels/ads.scss
@@ -2,9 +2,9 @@
     img {
         max-width:100%;
         max-height:100%;
-        width: auto;
-        height: auto;
-        border: 1.5px $border-color solid;
+        width: 100%;
+        height: 100%;
+        border: 1px $border-color solid;
     }
     margin: 0 auto;
     height: inherit;


### PR DESCRIPTION
Currently, the ad panel doesn't align with every other panel due to a bug that this pull request addresses.

The ad-panel's width and height attributes are changed to 100% from auto, letting the image stretch.
The ad panel's border is also changed to 1px to:
1. Align with other panels
2. Better unity in design
3. Looks better 

These two changes fixes the alignment problem.
